### PR TITLE
Eks example updates

### DIFF
--- a/eks/.gitignore
+++ b/eks/.gitignore
@@ -1,3 +1,4 @@
 .terraform
 terraform.tfstate
 terraform.tfstate.backup
+terraform.tfvars

--- a/eks/kubernetes/setup-volumes.sh
+++ b/eks/kubernetes/setup-volumes.sh
@@ -26,4 +26,4 @@ _kubectl patch storageclass gp2 -p '{
 }'
 
 # Add our new default storageclass.
-_kubectl apply -f ebs-storageclass.yaml
+_kubectl apply -f kubernetes/ebs-storageclass.yaml

--- a/eks/terraform/eks-worker-nodes.tf
+++ b/eks/terraform/eks-worker-nodes.tf
@@ -46,7 +46,7 @@ resource "aws_iam_instance_profile" "blimp-node" {
 
 resource "aws_key_pair" "blimp-node" {
   key_name   = "blimp-node"
-  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCZEqFYjJeQj+oBPP6HXHFkS0jr02H3lXUhaWq9zZ4z55oOrVBjTduzlleaxFKptjU7qxT6fno+a1JVZlCjnWJREpiVSKZe5bgQAMUChpfLX2luV/mDy7OeSzQIRhAmDFxvBFlKtI0hWqkGq81KQOMN6lQj8fJQXBSGAV3sQBj6fukGWhHfiPc3lZCtVZxUx6wmDklnAWogfh5AGBA4Ltm8vrY3E5SPBCCIdAbJMgNPXQ6/AQqbndG4+TnKWUZbebtp5yiechnZ5yz92fk2Zz9GQzlTGyH1jqyRfGzQsv4SAsRicD2+rfoGNENh7WMFr+sptMQaUdil4Mw/DD76J+Xn"
+  public_key = file(var.public-key-path)
 }
 
 data "aws_ami" "blimp-node-image" {

--- a/eks/terraform/providers.tf
+++ b/eks/terraform/providers.tf
@@ -3,7 +3,7 @@
 #
 
 provider "aws" {
-  region  = "us-west-2"
+  region  = var.aws-region
   version = ">= 2.68.0"
 }
 

--- a/eks/terraform/terraform.tfvars.example
+++ b/eks/terraform/terraform.tfvars.example
@@ -1,0 +1,2 @@
+public-key-path = "~/.ssh/id_rsa.pub"
+aws-region = "us-west-1"

--- a/eks/terraform/variables.tf
+++ b/eks/terraform/variables.tf
@@ -6,3 +6,15 @@ variable "cluster-name" {
   default = "terraform-eks-blimp"
   type    = string
 }
+
+variable "public-key-path" {
+  default = "~/.ssh/id_rsa.pub"
+  description = "Path to public SSH key for EC2 instances"
+  type = string
+}
+
+variable "aws-region" {
+  default = "us-west-2"
+  description = "Target AWS region"
+  type = string
+}


### PR DESCRIPTION
* Fixes issue of a 'file not found' when running `./kubernetes/setup-volumes.sh` from the eks directory (as stated in step 5 of the README).
* Changed the Terraform code to load a file for the ssh public key. (so there isn't a need to change the Terraform code when configuring)
* Added an example/placeholder of a `.tfvars` file.  This should allow for setting config variables without having to change the Terraform code.
